### PR TITLE
NT Added openjdk 6, and oracle jdk 8 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
 jdk:
+- oraclejdk8
 - oraclejdk7
 - openjdk7
+- openjdk6


### PR DESCRIPTION
Project is supposed to be Java 6 compatible. Travis doesn't support sun jdk 6, but it does have open jdk so added that. Also added oracle java 8 because why not.
