### PR TITLE
Added License checking maven plugin to build lifecycle

### DIFF
--- a/core/src/main/java/com/brandwatch/robots/parser/RobotsParser.java
+++ b/core/src/main/java/com/brandwatch/robots/parser/RobotsParser.java
@@ -1,5 +1,38 @@
 package com.brandwatch.robots.parser;
 
+/*
+ * #%L
+ * Robots (core)
+ * %%
+ * Copyright (C) 2015 Brandwatch
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Brandwatch nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
 import javax.annotation.Nonnull;
 
 public interface RobotsParser {

--- a/core/src/main/javacc/RobotsParser.jj
+++ b/core/src/main/javacc/RobotsParser.jj
@@ -27,6 +27,39 @@ PARSER_BEGIN(RobotsParserImpl)
 
 package com.brandwatch.robots.parser;
 
+/*
+ * #%L
+ * Robots (core)
+ * %%
+ * Copyright (C) 2015 Brandwatch
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Brandwatch nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
 public class RobotsParserImpl implements RobotsParser {
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,17 @@
 
     <name>Robots (parent)</name>
     <description>Parent module for robots exclusion protocol library.</description>
+    <inceptionYear>2015</inceptionYear>
 
+    <licenses>
+        <license>
+            <name>BSD 3-Clause License</name>
+            <url>http://opensource.org/licenses/BSD-3-Clause</url>
+            <distribution>repo</distribution>
+            <comments>A permissive free software license</comments>
+        </license>
+    </licenses>
+    
     <modules>
         <module>core</module>
         <module>integration-tests</module>
@@ -50,6 +60,11 @@
 
         <hamcrest-version>1.3</hamcrest-version>
     </properties>
+
+    <organization>
+        <name>Brandwatch</name>
+        <url>http://www.brandwatch.com</url>
+    </organization>
 
     <developers>
         <developer>
@@ -337,6 +352,29 @@
                     </configuration>
                 </plugin>
 
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>1.8</version>
+                    <configuration>
+                        <licenseName>bsd_3</licenseName>
+                        <failOnMissingHeader>true</failOnMissingHeader>
+                        <failOnNotUptodateHeader>true</failOnNotUptodateHeader>
+                        <roots>
+                            <root>src/main</root>
+                            <root>src/test</root>
+                        </roots>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>check-file-header</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
             </plugins>
         </pluginManagement>
 
@@ -354,6 +392,12 @@
                     </sourceDirectories>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -358,8 +358,6 @@
                     <version>1.8</version>
                     <configuration>
                         <licenseName>bsd_3</licenseName>
-                        <failOnMissingHeader>true</failOnMissingHeader>
-                        <failOnNotUptodateHeader>true</failOnNotUptodateHeader>
                         <roots>
                             <root>src/main</root>
                             <root>src/test</root>
@@ -374,6 +372,10 @@
                             <goals>
                                 <goal>check-file-header</goal>
                             </goals>
+                            <configuration>
+                                <failOnMissingHeader>true</failOnMissingHeader>
+                                <failOnNotUptodateHeader>true</failOnNotUptodateHeader>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
             <comments>A permissive free software license</comments>
         </license>
     </licenses>
-    
+
     <modules>
         <module>core</module>
         <module>integration-tests</module>
@@ -364,6 +364,9 @@
                             <root>src/main</root>
                             <root>src/test</root>
                         </roots>
+                        <extraExtensions>
+                            <jj>java</jj>
+                        </extraExtensions>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
I want to fail PRs that don't have up-to-date license headers. This PR makes those changes, and also tests it works by introducing commits that deliberately fail. 
