### PR TITLE
Add ghpages site generation and deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <hamcrest-version>1.3</hamcrest-version>
-        <github.global.server>github</github.global.server>
     </properties>
 
     <organization>
@@ -410,25 +409,6 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>com.github.github</groupId>
-                <artifactId>site-maven-plugin</artifactId>
-                <version>0.11</version>
-                <configuration>
-                    <message>Creating site for ${project.version}</message>
-                    <path>${project.distributionManagement.site.url}</path>
-                    <merge>true</merge>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>site</goal>
-                        </goals>
-                        <phase>site</phase>
-                    </execution>
-                </executions>
-            </plugin>
-
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -463,4 +443,40 @@
         </plugins>
 
     </reporting>
+
+    <profiles>
+        <profile>
+            <id>ghpages-site-deploy</id>
+
+            <properties>
+                <github.global.server>github</github.global.server>
+            </properties>
+
+            <build>
+                <plugins>
+
+                    <plugin>
+                        <groupId>com.github.github</groupId>
+                        <artifactId>site-maven-plugin</artifactId>
+                        <version>0.11</version>
+                        <configuration>
+                            <message>Creating site for ${project.version}</message>
+                            <path>${project.distributionManagement.site.url}</path>
+                            <merge>true</merge>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>site</goal>
+                                </goals>
+                                <phase>site</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <hamcrest-version>1.3</hamcrest-version>
+        <github.global.server>github</github.global.server>
     </properties>
 
     <organization>
@@ -380,6 +381,12 @@
                     </executions>
                 </plugin>
 
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>2.8</version>
+                </plugin>
+
             </plugins>
         </pluginManagement>
 
@@ -397,6 +404,25 @@
                     </sourceDirectories>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.11</version>
+                <configuration>
+                    <message>Creating site for ${project.version}</message>
+                    <merge>true</merge>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>site</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
             <id>sonatype-nexus-staging</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
+        <site>
+            <id>github-pages-site</id>
+            <name>Deployment through GitHub's site deployment plugin</name>
+            <url>site/${project.version}</url>
+        </site>
     </distributionManagement>
 
     <scm>
@@ -411,6 +416,7 @@
                 <version>0.11</version>
                 <configuration>
                     <message>Creating site for ${project.version}</message>
+                    <path>${project.distributionManagement.site.url}</path>
                     <merge>true</merge>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.1</version>
+                    <version>2.10.2</version>
                     <configuration>
                         <encoding>UTF-8</encoding>
                         <quiet>true</quiet>
@@ -448,6 +448,12 @@
                     </reportSet>
                 </reportSets>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+
         </plugins>
 
     </reporting>


### PR DESCRIPTION
Update configuration to automatically build and deploy a maven site to github (gh-pages).  This will include all the standard maven site information. I'll add a few extra reports for JavaDoc and the like. 
