### PR TITLE
NT Abstracted parser implementation

### DIFF
--- a/core/src/main/java/com/brandwatch/robots/RobotsFactory.java
+++ b/core/src/main/java/com/brandwatch/robots/RobotsFactory.java
@@ -45,6 +45,8 @@ import com.brandwatch.robots.matching.MatcherUtilsImpl;
 import com.brandwatch.robots.net.CharSourceSupplier;
 import com.brandwatch.robots.net.CharSourceSupplierHttpClientImpl;
 import com.brandwatch.robots.net.LoggingClientFilter;
+import com.brandwatch.robots.parser.RobotsParser;
+import com.brandwatch.robots.parser.RobotsParserImpl;
 import com.brandwatch.robots.util.LogLevel;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -55,6 +57,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
+import java.io.Reader;
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
@@ -166,5 +169,10 @@ public class RobotsFactory {
     @Nonnull
     public MatcherUtils getMatcherUtils() {
         return matcherUtils;
+    }
+
+    @Nonnull
+    public RobotsParser createRobotsParser(@Nonnull Reader reader) {
+        return new RobotsParserImpl(checkNotNull(reader, "reader is null"));
     }
 }

--- a/core/src/main/java/com/brandwatch/robots/RobotsLoaderImpl.java
+++ b/core/src/main/java/com/brandwatch/robots/RobotsLoaderImpl.java
@@ -115,7 +115,7 @@ final class RobotsLoaderImpl implements RobotsLoader {
         log.debug("Conditional allow; parsing contents of {}", robotsResource);
 
         final Reader reader = new LoggingReader(robotsData, this.getClass(), LogLevel.TRACE);
-        final RobotsParser parser = new RobotsParser(reader);
+        final RobotsParser parser = factory.createRobotsParser(reader);
         final RobotsBuildingParseHandler handler = factory.createRobotsBuildingHandler();
 
         try {

--- a/core/src/main/java/com/brandwatch/robots/parser/RobotsParser.java
+++ b/core/src/main/java/com/brandwatch/robots/parser/RobotsParser.java
@@ -1,0 +1,9 @@
+package com.brandwatch.robots.parser;
+
+import javax.annotation.Nonnull;
+
+public interface RobotsParser {
+
+    void parse(@Nonnull RobotsParseHandler handler) throws ParseException;
+
+}

--- a/core/src/main/javacc/RobotsParser.jj
+++ b/core/src/main/javacc/RobotsParser.jj
@@ -23,14 +23,14 @@ options {
   FORCE_LA_CHECK = false;
 }
 
-PARSER_BEGIN(RobotsParser)
+PARSER_BEGIN(RobotsParserImpl)
 
 package com.brandwatch.robots.parser;
 
-public class RobotsParser {
+public class RobotsParserImpl implements RobotsParser {
 }
 
-PARSER_END(RobotsParser)
+PARSER_END(RobotsParserImpl)
 
 SKIP :
 {

--- a/core/src/test/java/com/brandwatch/robots/AbstractDataTest.java
+++ b/core/src/test/java/com/brandwatch/robots/AbstractDataTest.java
@@ -34,6 +34,7 @@ package com.brandwatch.robots;
  */
 
 import com.brandwatch.robots.parser.RobotsParser;
+import com.brandwatch.robots.parser.RobotsParserImpl;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
@@ -80,7 +81,7 @@ public abstract class AbstractDataTest {
 
     @Before
     public final void setupAbstractTest() throws IOException {
-        robotsTxtParser = new RobotsParser(resourceReader(resourceName));
+        robotsTxtParser = new RobotsParserImpl(resourceReader(resourceName));
     }
 
 }

--- a/core/src/test/java/com/brandwatch/robots/RobotsBuildingParseHandlerFunctionalTest.java
+++ b/core/src/test/java/com/brandwatch/robots/RobotsBuildingParseHandlerFunctionalTest.java
@@ -38,6 +38,7 @@ import com.brandwatch.robots.matching.ExpressionCompiler;
 import com.brandwatch.robots.matching.Matcher;
 import com.brandwatch.robots.parser.ParseException;
 import com.brandwatch.robots.parser.RobotsParser;
+import com.brandwatch.robots.parser.RobotsParserImpl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -61,7 +62,7 @@ public class RobotsBuildingParseHandlerFunctionalTest {
     @Test
     public void givenDailyMailBoards_whenParse_thenRobotsObjectEqualsExpected() throws IOException, ParseException {
         Reader reader = resourceReader("http_boards.dailymail.co.uk_robots.txt");
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser = new RobotsParserImpl(reader);
         RobotsBuildingParseHandler handler = new RobotsBuildingParseHandler(
                 pathExpressionCompiler,
                 agentExpressionCompiler);
@@ -86,8 +87,7 @@ public class RobotsBuildingParseHandlerFunctionalTest {
     @Test
     public void givenWwwBrandwatchCom_whenParse_thenRobotsObjectEqualsExpected() throws IOException, ParseException {
         Reader reader = resourceReader("http_www.brandwatch.com_robots.txt");
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
-        RobotsConfig config = new RobotsConfig();
+        RobotsParser robotsTxtParser = new RobotsParserImpl(reader);
         RobotsBuildingParseHandler handler = new RobotsBuildingParseHandler(pathExpressionCompiler, agentExpressionCompiler);
         robotsTxtParser.parse(handler);
 

--- a/core/src/test/java/com/brandwatch/robots/RobotsLoaderImplTest.java
+++ b/core/src/test/java/com/brandwatch/robots/RobotsLoaderImplTest.java
@@ -82,6 +82,7 @@ public class RobotsLoaderImplTest {
         when(factory.createDisallowAllRobots()).thenReturn(DISALLOW_ALL);
         when(factory.createCharSourceSupplier()).thenReturn(charSourceSupplier);
 
+        when(factory.createRobotsParser(any(Reader.class))).thenCallRealMethod();
         instance = new RobotsLoaderImpl(factory);
     }
 

--- a/core/src/test/java/com/brandwatch/robots/parser/RobotsParserImplAcceptedDataTest.java
+++ b/core/src/test/java/com/brandwatch/robots/parser/RobotsParserImplAcceptedDataTest.java
@@ -46,13 +46,13 @@ import java.io.InputStream;
 import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
-public class RobotsParserAcceptedDataTest {
+public class RobotsParserImplAcceptedDataTest {
 
     private final InputStream data;
     private RobotsParseHandler handler;
     private RobotsParser robotsTxtParser;
 
-    public RobotsParserAcceptedDataTest(String data) {
+    public RobotsParserImplAcceptedDataTest(String data) {
         this.data = new ByteArrayInputStream(data.getBytes());
     }
 
@@ -84,7 +84,7 @@ public class RobotsParserAcceptedDataTest {
     @Before
     public void setup() throws IOException {
         handler = mock(RobotsParseHandler.class);
-        robotsTxtParser = new RobotsParser(data);
+        robotsTxtParser = new RobotsParserImpl(data);
     }
 
     @Test

--- a/core/src/test/java/com/brandwatch/robots/parser/RobotsParserImplDataTest.java
+++ b/core/src/test/java/com/brandwatch/robots/parser/RobotsParserImplDataTest.java
@@ -44,11 +44,11 @@ import java.io.IOException;
 import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
-public class RobotsParserDataTest extends AbstractDataTest {
+public class RobotsParserImplDataTest extends AbstractDataTest {
 
     private RobotsParseHandler handler;
 
-    public RobotsParserDataTest(String resourceName) {
+    public RobotsParserImplDataTest(String resourceName) {
         super(resourceName);
     }
 

--- a/core/src/test/java/com/brandwatch/robots/parser/RobotsParserImplFunctionalTest.java
+++ b/core/src/test/java/com/brandwatch/robots/parser/RobotsParserImplFunctionalTest.java
@@ -46,7 +46,7 @@ import static com.brandwatch.robots.AbstractDataTest.resourceReader;
 import static org.mockito.Mockito.inOrder;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RobotsParserFunctionalTest {
+public class RobotsParserImplFunctionalTest {
 
     @Mock
     private RobotsParseHandler handler;
@@ -54,7 +54,7 @@ public class RobotsParserFunctionalTest {
     @Test
     public void givenDailyMailBoards_whenParse_thenHandlerInteractionsAreExpected() throws IOException, ParseException {
         Reader reader = resourceReader("http_boards.dailymail.co.uk_robots.txt");
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser = new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         InOrder o = inOrder(handler);
         o.verify(handler).startEntry();
@@ -72,7 +72,7 @@ public class RobotsParserFunctionalTest {
     @Test
     public void givenDailyMail_whenParse_thenHandlerInteractionsAreExpected() throws IOException, ParseException {
         Reader reader = resourceReader("http_www.dailymail.co.uk_robots.txt");
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser = new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
 
         InOrder o = inOrder(handler);
@@ -241,7 +241,7 @@ public class RobotsParserFunctionalTest {
     @Test
     public void giveWwwGoogleCom_whenParse_thenHandlerInteractionsAreExpected() throws IOException, ParseException {
         Reader reader = resourceReader("http_www.google.com_robots.txt");
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser = new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         InOrder o = inOrder(handler);
         o.verify(handler).startEntry();
@@ -560,7 +560,7 @@ public class RobotsParserFunctionalTest {
     @Test
     public void givenWwwBrandwatchCom_whenParse_thenHandlerInteractionsAreExpected() throws IOException, ParseException {
         Reader reader = resourceReader("http_www.brandwatch.com_robots.txt");
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser = new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         InOrder o = inOrder(handler);
 

--- a/core/src/test/java/com/brandwatch/robots/parser/RobotsParserImplTest.java
+++ b/core/src/test/java/com/brandwatch/robots/parser/RobotsParserImplTest.java
@@ -56,49 +56,49 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.withSettings;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RobotsParserTest {
+public class RobotsParserImplTest {
 
     @Mock
     private RobotsParseHandler handler;
 
     @Test(expected = NullPointerException.class)
     public void givenNullInputStream_whenNewInstance_thenThrowsNPE() {
-        new RobotsParser((InputStream) null);
+        new RobotsParserImpl((InputStream) null);
     }
 
 
     @Test
     public void givenEmptyStream_whenParser_thenNoExceptionThrown() throws IOException, ParseException {
         final InputStream inputStream = ByteSource.empty().openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(inputStream);
+        RobotsParser robotsTxtParser = new RobotsParserImpl(inputStream);
         robotsTxtParser.parse(handler);
     }
 
     @Test
     public void givenEmptyReader_whenParse_thenNoExceptionThrown() throws IOException, ParseException {
         Reader reader = CharSource.empty().openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser = new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
     }
 
     @Test
     public void givenSingleBlankLine_whenParse_thenNoExceptionThrown() throws IOException, ParseException {
         Reader reader = CharSource.wrap("\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser = new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
     }
 
     @Test
     public void givenSingleCommentLine_whenParse_thenNoExceptionThrown() throws IOException, ParseException {
         Reader reader = CharSource.wrap("# comment line \n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser = new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
     }
 
     @Test
     public void givenTwoCommentLines_whenParse_thenNoExceptionThrown() throws IOException, ParseException {
         Reader reader = CharSource.wrap("# comment line 1 \n# comment line 2 \n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser = new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
     }
 
@@ -106,7 +106,7 @@ public class RobotsParserTest {
     @Test
     public void givenLowerCaseUserAgentLine_whenParse_thenHandlerCalledWithExpectedAgent() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: example-bot\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).userAgent("example-bot");
     }
@@ -114,7 +114,7 @@ public class RobotsParserTest {
     @Test
     public void givenUpperCaseUserAgentLine_whenParse_thenHandlerCalledWithExpectedAgent() throws IOException, ParseException {
         Reader reader = CharSource.wrap("USER-AGENT: example-bot\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).userAgent("example-bot");
     }
@@ -122,7 +122,7 @@ public class RobotsParserTest {
     @Test
     public void givenMixedCaseUserAgentLine_whenParse_thenHandlerCalledWithExpectedAgent() throws IOException, ParseException {
         Reader reader = CharSource.wrap("uSeR-aGeNt: example-bot\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).userAgent("example-bot");
     }
@@ -130,7 +130,7 @@ public class RobotsParserTest {
     @Test
     public void givenTwoUserAgentLines_whenParse_thenHandlerCalledWithExpectedAgent() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: first\nuser-agent: second\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).userAgent("first");
         verify(handler).userAgent("second");
@@ -139,7 +139,7 @@ public class RobotsParserTest {
     @Test
     public void givenMixedCaseUserAgentLine_whenParse_thenStartEntryCalled() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: example-bot\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).startEntry();
     }
@@ -147,7 +147,7 @@ public class RobotsParserTest {
     @Test
     public void givenMixedCaseUserAgentLine_whenParse_thenEndEntryCalled() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: example-bot\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).endEntry();
     }
@@ -155,7 +155,7 @@ public class RobotsParserTest {
     @Test
     public void givenEmpty_whenParse_thenZeroInteractionOnHandler() throws IOException, ParseException {
         Reader reader = CharSource.empty().openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verifyZeroInteractions(handler);
     }
@@ -163,7 +163,7 @@ public class RobotsParserTest {
     @Test
     public void givenUserAgentMissingEOL_whenParse_thenEndEntryCalled() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: example-bot").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).endEntry();
     }
@@ -171,7 +171,7 @@ public class RobotsParserTest {
     @Test
     public void givenEmptyDisallow_whenParse_thenDisallowCalledWithEmptyString() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: example-bot\ndisallow:\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).disallow("");
     }
@@ -180,7 +180,7 @@ public class RobotsParserTest {
     @Test
     public void givenUserAgentWithTrailingSpace_whenParse_thenAgentIsTrimmed() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: example-bot \n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).userAgent("example-bot");
     }
@@ -189,7 +189,7 @@ public class RobotsParserTest {
     @Test
     public void givenUserAgentEndingInComment_whenParse_thenAgentProduced() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: example-bot # some comment\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).userAgent("example-bot");
     }
@@ -198,7 +198,7 @@ public class RobotsParserTest {
     @Test
     public void givenBlankLineSeparatedAgents_whenParse_thenAgentsProduced() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: example-bot\n\n\n\nuser-agent: naughty-bot").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).userAgent("example-bot");
         verify(handler).userAgent("naughty-bot");
@@ -208,7 +208,7 @@ public class RobotsParserTest {
     @Test
     public void givenTrailingNewLines_whenParse_thenAgentProduced() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: example-bot\n\n\n\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).userAgent("example-bot");
     }
@@ -216,7 +216,7 @@ public class RobotsParserTest {
     @Test
     public void givenHostRule_whenParse_thenDirectiveProduced() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: *\nhost: example.com\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).otherDirective("host", "example.com");
     }
@@ -225,7 +225,7 @@ public class RobotsParserTest {
     @Test
     public void givenCrawlDelayRule_whenParse_thenDirectiveProduced() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: *\ncrawl-delay: 10\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).otherDirective("crawl-delay", "10");
     }
@@ -234,7 +234,7 @@ public class RobotsParserTest {
     @Test
     public void givenUnsupportedRule_whenParse_thenDirectiveProduced() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: *\nCheese-burgers: yummy\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).otherDirective("Cheese-burgers", "yummy");
     }
@@ -242,7 +242,7 @@ public class RobotsParserTest {
     @Test
     public void givenMissingFinalEOL_whenParse_thenDirectiveProduced() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: *\nallow: /").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).allow("/");
     }
@@ -250,7 +250,7 @@ public class RobotsParserTest {
     @Test
     public void givenMissingPath_whenParse_thenDirectiveProduced() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: *\nallow:\n").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).allow("");
     }
@@ -258,7 +258,7 @@ public class RobotsParserTest {
     @Test
     public void givenMissingPathAndEOL_whenParse_thenDirectiveProduced() throws IOException, ParseException {
         Reader reader = CharSource.wrap("user-agent: *\nallow:").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
         verify(handler).allow("");
     }
@@ -266,7 +266,7 @@ public class RobotsParserTest {
     @Test
     public void givenCommentMissingEOL_whenParse_thenNoExceptionThrown() throws IOException, ParseException {
         Reader reader = CharSource.wrap("#").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
     }
 
@@ -280,7 +280,7 @@ public class RobotsParserTest {
                 "<h1>Some text</h1>\n" +
                 "</body>\n" +
                 "</html>").openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(reader);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(reader);
         robotsTxtParser.parse(handler);
     }
 
@@ -334,7 +334,7 @@ public class RobotsParserTest {
         String input = "user-agent: example-bot\nallow: /\n";
         byte[] inputBytes = input.getBytes(actualEncoding);
         final InputStream inputStream = ByteSource.wrap(inputBytes).openStream();
-        RobotsParser robotsTxtParser = new RobotsParser(inputStream);
+        RobotsParser robotsTxtParser =new RobotsParserImpl(inputStream);
         robotsTxtParser.parse(handler);
     }
 

--- a/core/src/test/java/com/brandwatch/robots/parser/RobotsParserRejectedDataTest.java
+++ b/core/src/test/java/com/brandwatch/robots/parser/RobotsParserRejectedDataTest.java
@@ -83,7 +83,7 @@ public class RobotsParserRejectedDataTest {
     @Before
     public void setup() throws IOException {
         handler = mock(RobotsParseHandler.class);
-        robotsTxtParser = new RobotsParser(data);
+        robotsTxtParser = new RobotsParserImpl(data);
     }
 
     @Test(expected = ParseException.class)


### PR DESCRIPTION
I'm working on the improving test coverage, and it's hard to unit test dependants of the parser because it's not sufficiently decouple. This PR abstracts to separate interface and implementation. 
- Renamed `RobotsParser` to `RobotsParserImpl`
- Introduces a new interface `RobotsParser` which is implemented by `RobotsParserImpl`.
- Move instantiation of  `RobotsParserImpl` to the factory. 
