### PR TITLE
Add javadoc to core api

### DIFF
--- a/core/src/main/java/com/brandwatch/robots/RobotsConfig.java
+++ b/core/src/main/java/com/brandwatch/robots/RobotsConfig.java
@@ -34,11 +34,7 @@ package com.brandwatch.robots;
  */
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
@@ -47,6 +43,26 @@ import java.nio.charset.Charset;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * Hold global configuration information for a {@link RobotsService} instance.
+ * <p/>
+ * <tt>RobotsConfig</tt> is mutable, so can be altered after the service has been
+ * instantiated. Note however that this is a bad idea, and is unlikely to work
+ * as intended.
+ * <p/>
+ * <tt>RobotsConfig</tt> is used to produce a {@link RobotsFactory} instance, which
+ * in turn produces the service:
+ * <pre>
+ *  RobotsConfig config = new RobotsConfig();
+ *  config.setCachedExpiresHours(48);
+ *  config.setCacheMaxSizeRecords(10000);
+ *  config.setMaxFileSizeBytes(192 * 1024);
+ *
+ *  RobotsFactory factory = new RobotsFactory(config);
+ *
+ *  RobotsService service = factory.createService();
+ * </pre>
+ */
 public class RobotsConfig {
 
     @Nonnegative
@@ -73,85 +89,183 @@ public class RobotsConfig {
     @Nonnegative
     private int readTimeoutMillis = 30000;
 
+    /**
+     * @return time in milliseconds before requests time out
+     * @see #setRequestTimeoutMillis(long)
+     */
     public long getRequestTimeoutMillis() {
         return requestTimeoutMillis;
     }
 
-    public void setRequestTimeoutMillis(long requestTimeoutMillis) {
+    /**
+     * Wait <em>at most</em> the given time in milliseconds for a response, when making a requests.
+     * <p/>
+     * A value of zero or less will timeout immediately.
+     *
+     * @param requestTimeoutMillis time in milliseconds before requests time out
+     */
+    public void setRequestTimeoutMillis(@Nonnegative long requestTimeoutMillis) {
         this.requestTimeoutMillis = requestTimeoutMillis;
     }
 
+    /**
+     * @return time in milliseconds before response reading times out
+     * @see #setReadTimeoutMillis(int)
+     */
     public int getReadTimeoutMillis() {
         return readTimeoutMillis;
     }
 
+    /**
+     * Download the payload contents for <em>at most</em> the given length of time,
+     * after a response has been received.
+     *
+     * If the time is exceeded, download will fail.
+     *
+     * @param readTimeoutMillis time in milliseconds before response reading times out
+     * @throws IllegalArgumentException when <tt>readTimeoutMillis</tt> is negative
+     */
     public void setReadTimeoutMillis(@Nonnegative int readTimeoutMillis) {
         checkArgument(readTimeoutMillis >= 0, "readTimeoutMillis is negative");
         this.readTimeoutMillis = readTimeoutMillis;
     }
 
+    /**
+     * @return user-agent string passed by HTTP client requests
+     * @see #setUserAgent(String)
+     */
     @Nonnull
     public String getUserAgent() {
         return userAgent;
     }
 
+    /**
+     * The user-agent identifier used to make requests.
+     *
+     * This is distinct from the user-agent used for matching directives.
+     *
+     * @param userAgent agent string passed by HTTP client requests
+     * @throws NullPointerException if <tt>userAgent</tt> is null
+     */
     public void setUserAgent(@Nonnull String userAgent) {
         checkNotNull(userAgent, "userAgent is null");
         this.userAgent = userAgent;
     }
 
+    /**
+     * @return default character set used to decode received <tt>robots.txt</tt> files
+     * @see #setDefaultCharset(Charset)
+     */
     @Nonnull
     public Charset getDefaultCharset() {
         return defaultCharset;
     }
 
+    /**
+     * Character set used to decode the response, when downloading <tt>robots.txt</tt>
+     * files, and no other information is available.
+     *
+     * @param defaultCharset default character set used to decode received <tt>robots.txt</tt> files
+     * @throws NullPointerException when <tt>defaultCharset</tt> is null
+     */
     public void setDefaultCharset(@Nonnull Charset defaultCharset) {
         checkNotNull(defaultCharset, "defaultCharset is null");
         this.defaultCharset = defaultCharset;
     }
 
+    /**
+     * @return maximum number of redirects to follow before giving up
+     * @see #setMaxRedirectHops(int)
+     */
     @Nonnegative
     public int getMaxRedirectHops() {
         return maxRedirectHops;
     }
 
+    /**
+     * Follow HTTP redirects up to the number of hops specified here,
+     * when requesting a <tt>robots.txt</tt> file.
+     *
+     * A value of zero indicates that
+     * no redirects will be followed.
+     *
+     * @param maxRedirectHops maximum number of redirects to follow before giving up
+     * @throws IllegalArgumentException when <tt>maxRedirectHops</tt> is negative
+     */
     public void setMaxRedirectHops(@Nonnegative int maxRedirectHops) {
         checkArgument(maxRedirectHops >= 0, "maxRedirectHops is negative");
         this.maxRedirectHops = maxRedirectHops;
     }
 
+    /**
+     * @return time in hours before cached <tt>robots.txt</tt> files are expired
+     * @see #setCacheExpiresHours(long)
+     */
     @Nonnegative
     public long getCacheExpiresHours() {
         return cacheExpiresHours;
     }
 
+    /**
+     * Time after which cached responses should be discarded, and new request be made.
+     * <p/>
+     * After retrieving and parsing a <tt>robots.txt</tt> file, the parsed response is
+     * cached. This is improve performance of subsequent requests, and reduce
+     * load on the target server.
+     *
+     * @param cacheExpiresHours time in hours before cached <tt>robots.txt</tt> files are expired
+     * @throws IllegalArgumentException when <tt>cacheExpiresHours</tt> is negative
+     */
     public void setCacheExpiresHours(@Nonnegative long cacheExpiresHours) {
         checkArgument(cacheExpiresHours >= 0, "cacheExpiresHours is negative");
         this.cacheExpiresHours = cacheExpiresHours;
     }
 
+    /**
+     * @return number of <tt>robots.txt</tt> records to store before evicting the oldest
+     * @see #setCacheMaxSizeRecords(long)
+     */
     @Nonnegative
     public long getCacheMaxSizeRecords() {
         return cacheMaxSizeRecords;
     }
 
+    /**
+     * Evict oldest cached records when the cache size exceeds this value.
+     *
+     * @param cacheMaxSizeRecords number of <tt>robots.txt</tt> records to store before evicting the oldest
+     * @throws IllegalArgumentException whe <tt>cacheMaxSizeRecords</tt> is negative
+     */
     public void setCacheMaxSizeRecords(@Nonnegative long cacheMaxSizeRecords) {
         checkArgument(cacheMaxSizeRecords >= 0, "cacheMaxSizeRecords is negative");
         this.cacheMaxSizeRecords = cacheMaxSizeRecords;
     }
 
+    /**
+     * @return maximum file size, in bytes, for downloaded <tt>robots.txt</tt> files
+     * @see #setMaxFileSizeBytes(int)
+     */
     @Nonnegative
     public int getMaxFileSizeBytes() {
         return maxFileSizeBytes;
     }
 
+    /**
+     * Limit file size to <em>at most</em> the given number of bytes, when
+     * downloading a <tt>robots.txt</tt>.
+     * <p/>
+     * Data before this limit are processed normally, but the remainder are discarded.
+     *
+     * @param maxFileSizeBytes maximum file size, in bytes, for downloaded <tt>robots.txt</tt> files
+     * @throws IllegalArgumentException when <tt>maxFileSizeBytes</tt> is negative
+     */
     public void setMaxFileSizeBytes(@Nonnegative int maxFileSizeBytes) {
         checkArgument(maxFileSizeBytes >= 0, "maxFileSizeBytes is negative");
         this.maxFileSizeBytes = maxFileSizeBytes;
     }
 
-
     @Override
+    @Nonnull
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("cacheExpiresHours", cacheExpiresHours)

--- a/core/src/main/java/com/brandwatch/robots/RobotsConfig.java
+++ b/core/src/main/java/com/brandwatch/robots/RobotsConfig.java
@@ -210,7 +210,7 @@ public class RobotsConfig {
      * Time after which cached responses should be discarded, and new request be made.
      * <p/>
      * After retrieving and parsing a <tt>robots.txt</tt> file, the parsed response is
-     * cached. This is improve performance of subsequent requests, and reduce
+     * cached. This is to improve performance of subsequent requests, and reduce
      * load on the target server.
      *
      * @param cacheExpiresHours time in hours before cached <tt>robots.txt</tt> files are expired

--- a/core/src/main/java/com/brandwatch/robots/RobotsFactory.java
+++ b/core/src/main/java/com/brandwatch/robots/RobotsFactory.java
@@ -48,6 +48,7 @@ import com.brandwatch.robots.net.LoggingClientFilter;
 import com.brandwatch.robots.parser.RobotsParser;
 import com.brandwatch.robots.parser.RobotsParserImpl;
 import com.brandwatch.robots.util.LogLevel;
+import com.google.common.annotations.Beta;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -64,6 +65,16 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * A <tt>RobotsFactory</tt> is used to create all the various components of the service.
+ *
+ * In particular, it can {@link #createService() create} the {@link RobotsService }
+ * facade, which is what most users will be interested in.
+ * <p />
+ * Note the <tt>@Beta</tt> annotation on various methods. While these methods are
+ * currently exposed, they aren't really part of the core API and so should be avoided.
+ * In future releases they are likely to change or disappear entirely, without further warning.
+ */
 public class RobotsFactory {
 
     private static final Logger log = LoggerFactory.getLogger(RobotsFactory.class);
@@ -83,15 +94,23 @@ public class RobotsFactory {
         log.debug("Initializing factory with config: {}", config);
     }
 
+    /**
+     * Construct a new factory instance from the given configuration.
+     *
+     * @param config global configuration options
+     * @throws NullPointerException when <tt>config</tt> is null
+     */
     public RobotsFactory(@Nonnull RobotsConfig config) {
         this(checkNotNull(config, "config is null"), new RobotsUtilities(), new MatcherUtilsImpl());
     }
 
+    @Beta
     @Nonnull
     public Robots createAllowAllRobots() {
         return createConstantRobots(PathDirective.Field.allow);
     }
 
+    @Beta
     @Nonnull
     public Robots createDisallowAllRobots() {
         return createConstantRobots(PathDirective.Field.disallow);
@@ -108,23 +127,27 @@ public class RobotsFactory {
                 .build();
     }
 
+    @Beta
     @Nonnull
     public RobotsUtilities getUtilities() {
         return utilities;
     }
 
     @Nonnull
+    @Beta
     public RobotsLoader createLoader() {
         return new RobotsLoaderCachedImpl(
                 new RobotsLoaderImpl(this),
                 createCache());
     }
 
+    @Beta
     @Nonnull
     public CharSourceSupplier createCharSourceSupplier() {
         return new CharSourceSupplierHttpClientImpl(config, createClient());
     }
 
+    @Beta
     @Nonnull
     public ExpressionCompiler createPathExpressionCompiler() {
         return new ExpressionCompilerBuilder()
@@ -133,6 +156,7 @@ public class RobotsFactory {
                 .build();
     }
 
+    @Beta
     @Nonnull
     public ExpressionCompiler createAgentExpressionCompiler() {
         return new ExpressionCompilerBuilder()
@@ -140,6 +164,7 @@ public class RobotsFactory {
                 .build();
     }
 
+    @Beta
     @Nonnull
     public Cache<URI, Robots> createCache() {
 
@@ -153,6 +178,11 @@ public class RobotsFactory {
                 .build();
     }
 
+    /**
+     * Instantiate a new service facade, used for checking robots.txt files.
+     *
+     * @return a new service facade instance
+     */
     @Nonnull
     public RobotsService createService() {
         RobotsServiceImpl service = new RobotsServiceImpl(
@@ -160,6 +190,7 @@ public class RobotsFactory {
         return service;
     }
 
+    @Beta
     @Nonnull
     public RobotsBuildingParseHandler createRobotsBuildingHandler() {
         return new RobotsBuildingParseHandler(
@@ -167,6 +198,7 @@ public class RobotsFactory {
                 createAgentExpressionCompiler());
     }
 
+    @Beta
     @Nonnull
     public Client createClient() {
         Client client = ClientBuilder.newClient()
@@ -175,11 +207,13 @@ public class RobotsFactory {
         return client;
     }
 
+    @Beta
     @Nonnull
     public MatcherUtils getMatcherUtils() {
         return matcherUtils;
     }
 
+    @Beta
     @Nonnull
     public RobotsParser createRobotsParser(@Nonnull Reader reader) {
         return new RobotsParserImpl(checkNotNull(reader, "reader is null"));

--- a/core/src/main/java/com/brandwatch/robots/RobotsService.java
+++ b/core/src/main/java/com/brandwatch/robots/RobotsService.java
@@ -36,8 +36,22 @@ package com.brandwatch.robots;
 import java.io.Closeable;
 import java.net.URI;
 
+/**
+ * <tt>RobotsService</tt> is a high-level facade over the whole robots library.
+ */
 public interface RobotsService extends Closeable {
 
-    boolean isAllowed(String crawlerAgentString, URI url);
+    /**
+     * Check whether a crawler is allowed to access the given resource.
+     * <p/>
+     * The user-agent string identifies the crawler, and is used to find
+     * matching agent directive groups. The resource is used to determine a <tt>robots.txt</tt>
+     * resource, and, if it exists, to match path directives therein.
+     *
+     * @param crawlerAgentString crawler identifier
+     * @param resource location of a resource we are checking for access to
+     * @return true if the crawler is allowed to access the resource, false otherwise
+     */
+    boolean isAllowed(String crawlerAgentString, URI resource);
 
 }


### PR DESCRIPTION
This PR includes Javadoc for areas of the code-base I would expect most users to be interested in. 

While there is a _lot_ of other public classes, there aren't really intended for user consumption, so I've omitted documenting them. Of particular concern is the RobotsFactory class, which exposes a large number of methods that really shouldn't be there. I'm considering restructuring that a bit, but in the mean time I've added guava s"Beta" annotations to indicate methods that shouldn't be relied upon. 

Closes #10
