### PR TITLE
Extract HTTP status code handling to a client fitler

### DIFF
--- a/core/src/main/java/com/brandwatch/robots/RobotsFactory.java
+++ b/core/src/main/java/com/brandwatch/robots/RobotsFactory.java
@@ -45,6 +45,7 @@ import com.brandwatch.robots.matching.MatcherUtilsImpl;
 import com.brandwatch.robots.net.CharSourceSupplier;
 import com.brandwatch.robots.net.CharSourceSupplierHttpClientImpl;
 import com.brandwatch.robots.net.FollowRedirectsFilter;
+import com.brandwatch.robots.net.HttpStatusHandler;
 import com.brandwatch.robots.net.LoggingClientFilter;
 import com.brandwatch.robots.parser.RobotsParser;
 import com.brandwatch.robots.parser.RobotsParserImpl;
@@ -204,6 +205,7 @@ public class RobotsFactory {
     public Client createClient() {
         Client client = ClientBuilder.newClient()
                 .register(new FollowRedirectsFilter(config.getMaxRedirectHops()))
+                .register(new HttpStatusHandler())
                 .register(new LoggingClientFilter(this.getClass(), LogLevel.TRACE));
         client.property(ClientProperties.READ_TIMEOUT, config.getReadTimeoutMillis());
         return client;

--- a/core/src/main/java/com/brandwatch/robots/RobotsLoaderImpl.java
+++ b/core/src/main/java/com/brandwatch/robots/RobotsLoaderImpl.java
@@ -36,6 +36,8 @@ package com.brandwatch.robots;
 import com.brandwatch.robots.domain.Robots;
 import com.brandwatch.robots.net.CharSourceSupplier;
 import com.brandwatch.robots.net.LoggingReader;
+import com.brandwatch.robots.net.TemporaryAllow;
+import com.brandwatch.robots.net.TemporaryDisallow;
 import com.brandwatch.robots.parser.ParseException;
 import com.brandwatch.robots.parser.RobotsParser;
 import com.brandwatch.robots.util.LogLevel;

--- a/core/src/main/java/com/brandwatch/robots/net/HttpStatusHandler.java
+++ b/core/src/main/java/com/brandwatch/robots/net/HttpStatusHandler.java
@@ -1,0 +1,105 @@
+package com.brandwatch.robots.net;
+
+/*
+ * #%L
+ * Robots (core)
+ * %%
+ * Copyright (C) 2014 - 2015 Brandwatch
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Brandwatch nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import javax.annotation.Nonnull;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.core.Response;
+
+import static java.text.MessageFormat.format;
+
+public class HttpStatusHandler implements ClientResponseFilter {
+
+    private static final int MULTI_STATUS = 207;
+    private static final int ALREADY_REPORTED = 208;
+    private static final int IM_USED = 226  ;
+
+    @Override
+    public void filter(@Nonnull ClientRequestContext requestContext, @Nonnull ClientResponseContext responseContext)
+            throws TemporaryAllow, TemporaryDisallow {
+        final Response.StatusType statusInfo = responseContext.getStatusInfo();
+        handleStatusCode(statusInfo);
+        handleStatus(statusInfo);
+        handleFamily(statusInfo);
+    }
+
+    private void handleStatusCode(@Nonnull Response.StatusType statusInfo) throws TemporaryDisallow {
+        switch (statusInfo.getStatusCode()) {
+            case MULTI_STATUS:
+            case ALREADY_REPORTED:
+            case IM_USED:
+                throw new TemporaryAllow(createStatusMessage(statusInfo));
+        }
+    }
+
+    private void handleStatus(@Nonnull Response.StatusType statusInfo) throws TemporaryDisallow {
+        final Response.Status status = Response.Status.fromStatusCode(statusInfo.getStatusCode());
+        if (status != null) {
+            switch (status) {
+                case NO_CONTENT:
+                case RESET_CONTENT:
+                    throw new TemporaryAllow(createStatusMessage(statusInfo));
+                case UNAUTHORIZED:
+                case FORBIDDEN:
+                case PAYMENT_REQUIRED:
+                    throw new TemporaryDisallow(createStatusMessage(statusInfo));
+            }
+        }
+    }
+
+    private void handleFamily(@Nonnull Response.StatusType statusInfo) throws TemporaryDisallow, TemporaryAllow {
+        switch (statusInfo.getFamily()) {
+            case SUCCESSFUL:
+                break;
+            case INFORMATIONAL:
+            case REDIRECTION:
+            case CLIENT_ERROR:
+            case OTHER:
+                throw new TemporaryAllow(createStatusMessage(statusInfo));
+            case SERVER_ERROR:
+                throw new TemporaryDisallow(createStatusMessage(statusInfo));
+            default:
+                throw new AssertionError("Unknown status family: " + statusInfo.getFamily());
+        }
+    }
+
+    private String createStatusMessage(@Nonnull Response.StatusType statusInfo) {
+        return (statusInfo.getReasonPhrase() != null)
+                ? format("response status: {0} \"{1}\"", statusInfo.getStatusCode(), statusInfo.getReasonPhrase())
+                : format("response status: {0}", statusInfo.getStatusCode());
+    }
+
+}

--- a/core/src/main/java/com/brandwatch/robots/net/TemporaryAllow.java
+++ b/core/src/main/java/com/brandwatch/robots/net/TemporaryAllow.java
@@ -1,4 +1,4 @@
-package com.brandwatch.robots;
+package com.brandwatch.robots.net;
 
 /*
  * #%L
@@ -33,9 +33,9 @@ package com.brandwatch.robots;
  * #L%
  */
 
-import java.io.IOException;
+import javax.ws.rs.WebApplicationException;
 
-public class TemporaryAllow extends IOException {
+public class TemporaryAllow extends WebApplicationException {
 
     private static final long serialVersionUID = -5465749384575181415L;
 

--- a/core/src/main/java/com/brandwatch/robots/net/TemporaryDisallow.java
+++ b/core/src/main/java/com/brandwatch/robots/net/TemporaryDisallow.java
@@ -1,4 +1,4 @@
-package com.brandwatch.robots;
+package com.brandwatch.robots.net;
 
 /*
  * #%L
@@ -33,9 +33,9 @@ package com.brandwatch.robots;
  * #L%
  */
 
-import java.io.IOException;
+import javax.ws.rs.WebApplicationException;
 
-public class TemporaryDisallow extends IOException {
+public class TemporaryDisallow extends WebApplicationException {
 
     private static final long serialVersionUID = -4504038118861545829L;
 

--- a/core/src/test/java/com/brandwatch/robots/RobotsLoaderImplTest.java
+++ b/core/src/test/java/com/brandwatch/robots/RobotsLoaderImplTest.java
@@ -35,6 +35,8 @@ package com.brandwatch.robots;
 
 import com.brandwatch.robots.domain.Robots;
 import com.brandwatch.robots.net.CharSourceSupplier;
+import com.brandwatch.robots.net.TemporaryAllow;
+import com.brandwatch.robots.net.TemporaryDisallow;
 import com.brandwatch.robots.parser.ParseException;
 import com.brandwatch.robots.parser.RobotsParseHandler;
 import com.brandwatch.robots.parser.RobotsParser;

--- a/core/src/test/java/com/brandwatch/robots/net/CharSourceSupplierHttpClientImplTest.java
+++ b/core/src/test/java/com/brandwatch/robots/net/CharSourceSupplierHttpClientImplTest.java
@@ -34,8 +34,6 @@ package com.brandwatch.robots.net;
  */
 
 import com.brandwatch.robots.RobotsConfig;
-import com.brandwatch.robots.TemporaryAllow;
-import com.brandwatch.robots.TemporaryDisallow;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteSource;
 import com.google.common.io.CharSource;
@@ -120,69 +118,6 @@ public class CharSourceSupplierHttpClientImplTest {
     public void givenExampleUri_whenGet_thenReturnsCharSource() throws IOException {
         CharSource result = instance.get(URI.create("http://example.com/robots.txt"));
         assertThat(result, notNullValue());
-    }
-
-    @Test(expected = TemporaryDisallow.class)
-    public void givenServerError_whenOpenStream_thenDisallowAll() throws IOException {
-        when(statusInfo.getFamily()).thenReturn(Family.SERVER_ERROR);
-        when(statusInfo.getStatusCode()).thenReturn(500);
-        when(statusInfo.getReasonPhrase()).thenReturn("Server Error");
-        CharSource source = instance.get(EXAMPLE_URI);
-        source.openStream();
-    }
-
-    @Test(expected = TemporaryAllow.class)
-    public void givenClientError_whenOpenStream_thenAllowAll() throws IOException {
-        when(statusInfo.getFamily()).thenReturn(Family.CLIENT_ERROR);
-        when(statusInfo.getStatusCode()).thenReturn(400);
-        when(statusInfo.getReasonPhrase()).thenReturn("Client Error");
-        CharSource source = instance.get(EXAMPLE_URI);
-        source.openStream();
-    }
-
-    @Test(expected = TemporaryDisallow.class)
-    public void givenUnauthorized_whenOpenStream_thenDisallowAll() throws IOException {
-        when(statusInfo.getFamily()).thenReturn(Family.CLIENT_ERROR);
-        when(statusInfo.getStatusCode()).thenReturn(401);
-        when(statusInfo.getReasonPhrase()).thenReturn("Unauthorized");
-        CharSource source = instance.get(EXAMPLE_URI);
-        source.openStream();
-    }
-
-    @Test(expected = TemporaryDisallow.class)
-    public void givenPaymentRequired_whenOpenStream_thenDisallowAll() throws IOException {
-        when(statusInfo.getFamily()).thenReturn(Family.CLIENT_ERROR);
-        when(statusInfo.getStatusCode()).thenReturn(402);
-        when(statusInfo.getReasonPhrase()).thenReturn("Payment Required");
-        CharSource source = instance.get(EXAMPLE_URI);
-        source.openStream();
-    }
-
-    @Test(expected = TemporaryDisallow.class)
-    public void givenForbidden_whenOpenStream_thenDisallowAll() throws IOException {
-        when(statusInfo.getFamily()).thenReturn(Family.CLIENT_ERROR);
-        when(statusInfo.getStatusCode()).thenReturn(403);
-        when(statusInfo.getReasonPhrase()).thenReturn("Forbidden");
-        CharSource source = instance.get(EXAMPLE_URI);
-        source.openStream();
-    }
-
-    @Test(expected = TemporaryAllow.class)
-    public void givenNotFound_whenOpenStream_thenAllowAll() throws IOException {
-        when(statusInfo.getFamily()).thenReturn(Family.CLIENT_ERROR);
-        when(statusInfo.getStatusCode()).thenReturn(404);
-        when(statusInfo.getReasonPhrase()).thenReturn("Not Found");
-        CharSource source = instance.get(EXAMPLE_URI);
-        source.openStream();
-    }
-
-    @Test(expected = TemporaryAllow.class)
-    public void givenOtherStatus_whenOpenStream_thenAllowAll() throws IOException {
-        when(statusInfo.getFamily()).thenReturn(Family.OTHER);
-        when(statusInfo.getStatusCode()).thenReturn(600);
-        when(statusInfo.getReasonPhrase()).thenReturn("Not Found");
-        CharSource source = instance.get(EXAMPLE_URI);
-        source.openStream();
     }
 
     @Test

--- a/core/src/test/java/com/brandwatch/robots/net/HttpStatusHandlerTest.java
+++ b/core/src/test/java/com/brandwatch/robots/net/HttpStatusHandlerTest.java
@@ -1,0 +1,195 @@
+package com.brandwatch.robots.net;
+
+/*
+ * #%L
+ * Robots (core)
+ * %%
+ * Copyright (C) 2014 - 2015 Brandwatch
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Brandwatch nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableList;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Parameterized.class)
+public class HttpStatusHandlerTest extends JerseyTest {
+
+    private static final String STATUS_PARAM = "status";
+
+    private final int statusCode;
+    private final Action expectedAction;
+
+    public HttpStatusHandlerTest(int statusCode, Action expectedAction) {
+        this.statusCode = statusCode;
+        this.expectedAction = expectedAction;
+    }
+
+    private enum Action {
+        TEMPORARY_ALLOW,
+        TEMPORARY_DISALLOW,
+        CONDITIONAL_ALLOW
+    }
+
+    @Path("/")
+    public static class TestResource {
+        @GET
+        public Response test(@QueryParam(STATUS_PARAM) int status) {
+            return Response.status(status).build();
+        }
+    }
+
+    @Override
+    protected Application configure() {
+        return new ResourceConfig(TestResource.class);
+    }
+
+    @Override
+    protected void configureClient(ClientConfig config) {
+        config.register(new HttpStatusHandler());
+    }
+
+    @Test
+    public void test() {
+        try {
+            final Response response = target()
+                    .queryParam(STATUS_PARAM, statusCode)
+                    .request()
+                    .get();
+            assertThat(response.getStatus(), equalTo(statusCode));
+        } catch (ProcessingException e) {
+            final Throwable cause = e.getCause();
+            if (cause == null) {
+                throw e;
+            } else if (cause instanceof TemporaryAllow) {
+                assertThat(expectedAction, equalTo(Action.TEMPORARY_ALLOW));
+            } else if (cause instanceof TemporaryDisallow) {
+                assertThat(expectedAction, equalTo(Action.TEMPORARY_DISALLOW));
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    @Parameterized.Parameters(name = "{index}: {0} => {1}")
+    public static Iterable<Object[]> data() {
+        return ImmutableList.of(
+                new Object[]{101, Action.TEMPORARY_ALLOW},
+                new Object[]{102, Action.TEMPORARY_ALLOW},
+                new Object[]{200, Action.CONDITIONAL_ALLOW},
+                new Object[]{201, Action.CONDITIONAL_ALLOW},
+                new Object[]{202, Action.CONDITIONAL_ALLOW},
+                new Object[]{203, Action.CONDITIONAL_ALLOW},
+                new Object[]{204, Action.TEMPORARY_ALLOW},
+                new Object[]{205, Action.TEMPORARY_ALLOW},
+                new Object[]{206, Action.CONDITIONAL_ALLOW},
+                new Object[]{207, Action.TEMPORARY_ALLOW},
+                new Object[]{208, Action.TEMPORARY_ALLOW},
+                new Object[]{226, Action.TEMPORARY_ALLOW},
+                new Object[]{300, Action.TEMPORARY_ALLOW},
+                new Object[]{301, Action.TEMPORARY_ALLOW},
+                new Object[]{302, Action.TEMPORARY_ALLOW},
+                new Object[]{303, Action.TEMPORARY_ALLOW},
+                new Object[]{304, Action.TEMPORARY_ALLOW},
+                new Object[]{305, Action.TEMPORARY_ALLOW},
+                new Object[]{306, Action.TEMPORARY_ALLOW},
+                new Object[]{307, Action.TEMPORARY_ALLOW},
+                new Object[]{308, Action.TEMPORARY_ALLOW},
+                new Object[]{400, Action.TEMPORARY_ALLOW},
+                new Object[]{401, Action.TEMPORARY_DISALLOW},
+                new Object[]{402, Action.TEMPORARY_DISALLOW},
+                new Object[]{403, Action.TEMPORARY_DISALLOW},
+                new Object[]{404, Action.TEMPORARY_ALLOW},
+                new Object[]{405, Action.TEMPORARY_ALLOW},
+                new Object[]{406, Action.TEMPORARY_ALLOW},
+                new Object[]{407, Action.TEMPORARY_ALLOW},
+                new Object[]{408, Action.TEMPORARY_ALLOW},
+                new Object[]{409, Action.TEMPORARY_ALLOW},
+                new Object[]{410, Action.TEMPORARY_ALLOW},
+                new Object[]{411, Action.TEMPORARY_ALLOW},
+                new Object[]{412, Action.TEMPORARY_ALLOW},
+                new Object[]{413, Action.TEMPORARY_ALLOW},
+                new Object[]{414, Action.TEMPORARY_ALLOW},
+                new Object[]{415, Action.TEMPORARY_ALLOW},
+                new Object[]{416, Action.TEMPORARY_ALLOW},
+                new Object[]{417, Action.TEMPORARY_ALLOW},
+                new Object[]{418, Action.TEMPORARY_ALLOW},
+                new Object[]{419, Action.TEMPORARY_ALLOW},
+                new Object[]{420, Action.TEMPORARY_ALLOW},
+                new Object[]{421, Action.TEMPORARY_ALLOW},
+                new Object[]{422, Action.TEMPORARY_ALLOW},
+                new Object[]{423, Action.TEMPORARY_ALLOW},
+                new Object[]{424, Action.TEMPORARY_ALLOW},
+                new Object[]{426, Action.TEMPORARY_ALLOW},
+                new Object[]{428, Action.TEMPORARY_ALLOW},
+                new Object[]{429, Action.TEMPORARY_ALLOW},
+                new Object[]{431, Action.TEMPORARY_ALLOW},
+                new Object[]{440, Action.TEMPORARY_ALLOW},
+                new Object[]{444, Action.TEMPORARY_ALLOW},
+                new Object[]{449, Action.TEMPORARY_ALLOW},
+                new Object[]{450, Action.TEMPORARY_ALLOW},
+                new Object[]{451, Action.TEMPORARY_ALLOW},
+                new Object[]{494, Action.TEMPORARY_ALLOW},
+                new Object[]{495, Action.TEMPORARY_ALLOW},
+                new Object[]{496, Action.TEMPORARY_ALLOW},
+                new Object[]{497, Action.TEMPORARY_ALLOW},
+                new Object[]{498, Action.TEMPORARY_ALLOW},
+                new Object[]{499, Action.TEMPORARY_ALLOW},
+                new Object[]{500, Action.TEMPORARY_DISALLOW},
+                new Object[]{501, Action.TEMPORARY_DISALLOW},
+                new Object[]{502, Action.TEMPORARY_DISALLOW},
+                new Object[]{503, Action.TEMPORARY_DISALLOW},
+                new Object[]{504, Action.TEMPORARY_DISALLOW},
+                new Object[]{505, Action.TEMPORARY_DISALLOW},
+                new Object[]{506, Action.TEMPORARY_DISALLOW},
+                new Object[]{507, Action.TEMPORARY_DISALLOW},
+                new Object[]{508, Action.TEMPORARY_DISALLOW},
+                new Object[]{509, Action.TEMPORARY_DISALLOW},
+                new Object[]{510, Action.TEMPORARY_DISALLOW},
+                new Object[]{511, Action.TEMPORARY_DISALLOW},
+                new Object[]{598, Action.TEMPORARY_DISALLOW},
+                new Object[]{599, Action.TEMPORARY_DISALLOW},
+                new Object[]{600, Action.TEMPORARY_ALLOW}
+        );
+    }
+
+}


### PR DESCRIPTION
This is part 2 of my exciting and epic adventures; in which a a heroic programmer sorts out the network connection code. If you haven't yet read part 1 (and in particular if it isn't merged yet) you should go check that out first: #27 

Today the hero of the story has has extracted the HTTP response code handling into another client filter. Responses for which we shouldn't even both trying to read the data, convert to exceptions that are caught further up the application stack.

Stay tuned for more gripping instalments 
