### PR TITLE
Fix JDK8 Javadoc errors when preparing releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <additionalparam>-Xdoclint:none</additionalparam>
 
         <hamcrest-version>1.3</hamcrest-version>
         <jersey-version>2.6</jersey-version>


### PR DESCRIPTION
When I was running `mvn release:prepare` I was getting errors because Java 8 is much stricter about self-closing HTML tags in Javadoc comments.

[I followed this advice which should fix it](http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html).
