### PR TITLE
Add an excludedDomains configuration, will skip matching to disallow

### DIFF
--- a/cli/src/main/java/com/brandwatch/robots/cli/Arguments.java
+++ b/cli/src/main/java/com/brandwatch/robots/cli/Arguments.java
@@ -41,6 +41,7 @@ import com.brandwatch.robots.cli.converters.URIConverter;
 import com.brandwatch.robots.cli.validators.AbsoluteURIValidator;
 import com.brandwatch.robots.cli.validators.NonEmptyStringValidator;
 import com.google.common.base.Charsets;
+import com.google.common.collect.Sets;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
@@ -74,6 +75,13 @@ public class Arguments {
             validateWith = PositiveInteger.class
     )
     private int maxRedirectHops = 5;
+
+    @Nonnull
+    @Parameter(
+            names = {"--excludedDomains", "-x"},
+            description = "Set of domains to always consider denied. Will consider, for each domain supplied, both exact matches of and any subdomain thereof to be excluded. Values are comma separated."
+    )
+    private List<String> excludedDomains = newArrayList();
 
     @Nonnull
     @Parameter(
@@ -149,6 +157,7 @@ public class Arguments {
         config.setMaxRedirectHops(getMaxRedirectHops());
         config.setDefaultCharset(getDefaultCharset());
         config.setReadTimeoutMillis(getReadTimeoutMillis());
+        config.setExcludedDomains(Sets.newHashSet(excludedDomains));
         return config;
     }
 

--- a/cli/src/test/java/com/brandwatch/robots/cli/ArgumentsTest.java
+++ b/cli/src/test/java/com/brandwatch/robots/cli/ArgumentsTest.java
@@ -429,11 +429,17 @@ public class ArgumentsTest {
         assertThat(config.getDefaultCharset(), equalTo(Charsets.UTF_16));
     }
 
-
     @Test
     public void givenReadTimeoutArgument_whenBuildRobotsConfig_thenReadTimeoutIsExpected() {
         jCommander.parse(array("--readTimeout", "123", FIRST_RESOURCE));
         RobotsConfig config = arguments.buildRobotsConfig();
         assertThat(config.getReadTimeoutMillis(), equalTo(123));
+    }
+
+    @Test
+    public void givenExcludedDomainsArgument_whenBuildRobotsConfig_thenExcludedDomainsAreExpected() {
+        jCommander.parse(array("--excludedDomains", "google.com,facebook.com,instagram.com", FIRST_RESOURCE));
+        RobotsConfig config = arguments.buildRobotsConfig();
+        assertThat(config.getExcludedDomains(), containsInAnyOrder("google.com", "facebook.com", "instagram.com"));
     }
 }

--- a/core/src/main/java/com/brandwatch/robots/RobotsConfig.java
+++ b/core/src/main/java/com/brandwatch/robots/RobotsConfig.java
@@ -39,6 +39,8 @@ import com.google.common.base.MoreObjects;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import java.nio.charset.Charset;
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -76,6 +78,9 @@ public class RobotsConfig {
 
     @Nonnegative
     private int maxRedirectHops = 5;
+
+    @Nonnull
+    private Set<String> excludedDomains = new HashSet<>();
 
     @Nonnull
     private Charset defaultCharset = Charsets.UTF_8;
@@ -128,6 +133,27 @@ public class RobotsConfig {
     public void setReadTimeoutMillis(@Nonnegative int readTimeoutMillis) {
         checkArgument(readTimeoutMillis >= 0, "readTimeoutMillis is negative");
         this.readTimeoutMillis = readTimeoutMillis;
+    }
+
+    /**
+     * @return the set of domains to <em>always</em> consider denied.
+     * @see #setExcludedDomains(Set)
+     */
+    @Nonnull
+    public Set<String> getExcludedDomains() {
+        return excludedDomains;
+    }
+
+    /**
+     * Allows robots resolution to be skipped for a set of domains, even after following redirects.
+     * Any matching domains will be considered disallowed.
+     * Both {@link String#equals(Object)} or {@link String#endsWith(String)} (prefixed with a '.' to match subdomains)
+     * are considered valid matches for the purposes of exclusion.
+     *
+     * @param excludedDomains Set of domains to <em>always</em> consider denied.
+     */
+    public void setExcludedDomains(@Nonnull Set<String> excludedDomains) {
+        this.excludedDomains = excludedDomains;
     }
 
     /**
@@ -276,6 +302,7 @@ public class RobotsConfig {
                 .add("userAgent", userAgent)
                 .add("requestTimeoutMillis", requestTimeoutMillis)
                 .add("readTimeoutMillis", readTimeoutMillis)
+                .add("excludedDomains", excludedDomains)
                 .toString();
     }
 }

--- a/core/src/main/java/com/brandwatch/robots/RobotsFactory.java
+++ b/core/src/main/java/com/brandwatch/robots/RobotsFactory.java
@@ -188,7 +188,7 @@ public class RobotsFactory {
     @Nonnull
     public RobotsService createService() {
         RobotsServiceImpl service = new RobotsServiceImpl(
-                createLoader(), getUtilities(), getMatcherUtils());
+                createLoader(), getUtilities(), getMatcherUtils(), config.getExcludedDomains());
         return service;
     }
 
@@ -204,7 +204,7 @@ public class RobotsFactory {
     @Nonnull
     public Client createClient() {
         Client client = ClientBuilder.newClient()
-                .register(new FollowRedirectsFilter(config.getMaxRedirectHops()))
+                .register(new FollowRedirectsFilter(config.getMaxRedirectHops(), config.getExcludedDomains()))
                 .register(new HttpStatusHandler())
                 .register(new LoggingClientFilter(this.getClass(), LogLevel.TRACE));
         client.property(ClientProperties.READ_TIMEOUT, config.getReadTimeoutMillis());

--- a/core/src/main/java/com/brandwatch/robots/net/exception/ExcludedDomainException.java
+++ b/core/src/main/java/com/brandwatch/robots/net/exception/ExcludedDomainException.java
@@ -1,0 +1,38 @@
+package com.brandwatch.robots.net.exception;
+
+/*
+ * #%L
+ * Robots (core)
+ * %%
+ * Copyright (C) 2014 - 2021 Brandwatch
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Brandwatch nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+public class ExcludedDomainException extends RuntimeException {
+
+}

--- a/core/src/test/java/com/brandwatch/robots/net/FollowRedirectsFilterTest.java
+++ b/core/src/test/java/com/brandwatch/robots/net/FollowRedirectsFilterTest.java
@@ -48,8 +48,13 @@ import javax.ws.rs.core.UriBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+
 public class FollowRedirectsFilterTest extends JerseyTest {
 
+    private static final Set<String> EXCLUDED_DOMAINS = Sets.newHashSet("example.com");
     private static final String RESOURCE_PAYLOAD = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
 
     @Path("test")
@@ -108,7 +113,7 @@ public class FollowRedirectsFilterTest extends JerseyTest {
 
     @Override
     protected void configureClient(ClientConfig config) {
-        config.register(new FollowRedirectsFilter(2));
+        config.register(new FollowRedirectsFilter(2, EXCLUDED_DOMAINS));
         config.property(ClientProperties.FOLLOW_REDIRECTS, false);
     }
 


### PR DESCRIPTION
- [x] Applies to both the target URL and any redirects it makes
- [x] Entries in the collection are matched by both
- Exact match to `URI.getHost()`
- Ends-With match to `"." + URI.getHost()`
- [x] Javadoc for the new configuration of the above
- [x] A new CLI parameter for the above