### PR TITLE
Set user agent in client request filter

### DIFF
--- a/cli/src/main/java/com/brandwatch/robots/cli/Arguments.java
+++ b/cli/src/main/java/com/brandwatch/robots/cli/Arguments.java
@@ -158,6 +158,7 @@ public class Arguments {
         config.setDefaultCharset(getDefaultCharset());
         config.setReadTimeoutMillis(getReadTimeoutMillis());
         config.setExcludedDomains(Sets.newHashSet(excludedDomains));
+        config.setUserAgent(agent);
         return config;
     }
 

--- a/core/src/main/java/com/brandwatch/robots/RobotsFactory.java
+++ b/core/src/main/java/com/brandwatch/robots/RobotsFactory.java
@@ -47,6 +47,7 @@ import com.brandwatch.robots.net.CharSourceSupplierHttpClientImpl;
 import com.brandwatch.robots.net.FollowRedirectsFilter;
 import com.brandwatch.robots.net.HttpStatusHandler;
 import com.brandwatch.robots.net.LoggingClientFilter;
+import com.brandwatch.robots.net.UserAgentBinder;
 import com.brandwatch.robots.parser.RobotsParser;
 import com.brandwatch.robots.parser.RobotsParserImpl;
 import com.brandwatch.robots.util.LogLevel;
@@ -206,6 +207,7 @@ public class RobotsFactory {
         Client client = ClientBuilder.newClient()
                 .register(new FollowRedirectsFilter(config.getMaxRedirectHops(), config.getExcludedDomains()))
                 .register(new HttpStatusHandler())
+                .register(new UserAgentBinder(config.getUserAgent()))
                 .register(new LoggingClientFilter(this.getClass(), LogLevel.TRACE));
         client.property(ClientProperties.READ_TIMEOUT, config.getReadTimeoutMillis());
         return client;

--- a/core/src/main/java/com/brandwatch/robots/net/CharSourceSupplierHttpClientImpl.java
+++ b/core/src/main/java/com/brandwatch/robots/net/CharSourceSupplierHttpClientImpl.java
@@ -95,7 +95,6 @@ public class CharSourceSupplierHttpClientImpl implements CharSourceSupplier {
         Future<Response> future = client.target(resource)
                 .request()
                 .accept(MediaType.TEXT_PLAIN_TYPE.withCharset(config.getDefaultCharset().displayName()))
-                .header(HttpHeaders.USER_AGENT, config.getUserAgent())
                 .buildGet()
                 .submit();
         try {

--- a/core/src/main/java/com/brandwatch/robots/net/UserAgentBinder.java
+++ b/core/src/main/java/com/brandwatch/robots/net/UserAgentBinder.java
@@ -1,0 +1,54 @@
+package com.brandwatch.robots.net;
+
+/*
+ * #%L
+ * Robots (core)
+ * %%
+ * Copyright (C) 2014 - 2021 Brandwatch
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Brandwatch nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import java.util.Collections;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+
+public class UserAgentBinder implements ClientRequestFilter {
+
+    private final String userAgent;
+
+    public UserAgentBinder(String userAgent) {
+        this.userAgent = userAgent;
+    }
+
+    @Override
+    public void filter(ClientRequestContext clientRequestContext) {
+        clientRequestContext.getHeaders().put(HttpHeaders.USER_AGENT, Collections.singletonList(userAgent));
+    }
+}

--- a/core/src/test/java/com/brandwatch/robots/net/UserAgentBinderTest.java
+++ b/core/src/test/java/com/brandwatch/robots/net/UserAgentBinderTest.java
@@ -1,0 +1,68 @@
+package com.brandwatch.robots.net;
+
+/*
+ * #%L
+ * Robots (core)
+ * %%
+ * Copyright (C) 2014 - 2021 Brandwatch
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Brandwatch nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserAgentBinderTest {
+
+    private static final String USER_AGENT = "iisbot/1.0 (+http://www.iis.net/iisbot.html)";
+    private static final UserAgentBinder USER_AGENT_BINDER = new UserAgentBinder(USER_AGENT);
+
+    @Mock
+    private MultivaluedMap<String, Object> headers;
+    @Mock
+    private ClientRequestContext clientRequestContext;
+
+    @Test
+    public void givenRequestContext_whenFilter_thenUserAgentIsSet() {
+        when(clientRequestContext.getHeaders()).thenReturn(headers);
+        USER_AGENT_BINDER.filter(clientRequestContext);
+        verify(headers).put(HttpHeaders.USER_AGENT, Collections.singletonList(USER_AGENT));
+    }
+
+}


### PR DESCRIPTION
Currently the user-agent header is only getting set on the initial request in https://github.com/BrandwatchLtd/robots/blob/master/core/src/main/java/com/brandwatch/robots/net/CharSourceSupplierHttpClientImpl.java#L98
Subsequent redirects are not setting the header in https://github.com/BrandwatchLtd/robots/blob/master/core/src/main/java/com/brandwatch/robots/net/FollowRedirectsFilter.java#L144-L152.

This PR registers a `ClientRequestFilter` called `UserAgentBinder` which binds the user-agent to all requests made from the client.
There is also a fix for the cli `--agent` parameter that was being ignored.

BEFORE: 

```
11:08:38.301 [jersey-client-async-executor-0] DEBUG com.brandwatch.robots.RobotsFactory - Request: GET http://citypaper.com:80/robots.txt {Accept=[text/plain; charset=UTF-8], User-Agent=[steve]}
11:08:38.950 [jersey-client-async-executor-0] DEBUG c.b.robots.net.FollowRedirectsFilter - Following redirect: http://citypaper.com:80/robots.txt => https://www.baltimoresun.com/citypaper/
11:08:38.951 [jersey-client-async-executor-0] DEBUG com.brandwatch.robots.RobotsFactory - Request: GET https://www.baltimoresun.com/citypaper/ {Accept=[text/plain; charset=UTF-8]}
11:08:39.317 [jersey-client-async-executor-0] DEBUG c.b.robots.net.FollowRedirectsFilter - Following redirect: https://www.baltimoresun.com/citypaper/ => http://www.tribpub.com/gdpr/baltimoresun.com/
11:08:39.318 [jersey-client-async-executor-0] DEBUG com.brandwatch.robots.RobotsFactory - Request: GET http://www.tribpub.com/gdpr/baltimoresun.com/ {Accept=[text/plain; charset=UTF-8]}
11:08:39.537 [jersey-client-async-executor-0] DEBUG c.b.robots.net.FollowRedirectsFilter - Following redirect: http://www.tribpub.com/gdpr/baltimoresun.com/ => https://www.tribpub.com/gdpr/baltimoresun.com/
11:08:39.538 [jersey-client-async-executor-0] DEBUG com.brandwatch.robots.RobotsFactory - Request: GET https://www.tribpub.com/gdpr/baltimoresun.com/ {Accept=[text/plain; charset=UTF-8]}
11:08:39.985 [jersey-client-async-executor-0] DEBUG c.b.robots.net.FollowRedirectsFilter - No redirect to follow:
```

AFTER: 
```
11:11:39.897 [jersey-client-async-executor-0] DEBUG com.brandwatch.robots.RobotsFactory - Request: GET http://citypaper.com:80/robots.txt {Accept=[text/plain; charset=UTF-8], User-Agent=[steve]}
11:11:40.876 [jersey-client-async-executor-0] DEBUG c.b.robots.net.FollowRedirectsFilter - Following redirect: http://citypaper.com:80/robots.txt => https://www.baltimoresun.com/citypaper/
11:11:40.877 [jersey-client-async-executor-0] DEBUG com.brandwatch.robots.RobotsFactory - Request: GET https://www.baltimoresun.com/citypaper/ {Accept=[text/plain; charset=UTF-8], User-Agent=[steve]}
11:11:41.370 [jersey-client-async-executor-0] DEBUG c.b.robots.net.FollowRedirectsFilter - Following redirect: https://www.baltimoresun.com/citypaper/ => http://www.tribpub.com/gdpr/baltimoresun.com/
11:11:41.371 [jersey-client-async-executor-0] DEBUG com.brandwatch.robots.RobotsFactory - Request: GET http://www.tribpub.com/gdpr/baltimoresun.com/ {Accept=[text/plain; charset=UTF-8], User-Agent=[steve]}
11:11:41.590 [jersey-client-async-executor-0] DEBUG c.b.robots.net.FollowRedirectsFilter - Following redirect: http://www.tribpub.com/gdpr/baltimoresun.com/ => https://www.tribpub.com/gdpr/baltimoresun.com/
11:11:41.590 [jersey-client-async-executor-0] DEBUG com.brandwatch.robots.RobotsFactory - Request: GET https://www.tribpub.com/gdpr/baltimoresun.com/ {Accept=[text/plain; charset=UTF-8], User-Agent=[steve]}
11:11:42.035 [jersey-client-async-executor-0] DEBUG c.b.robots.net.FollowRedirectsFilter - No redirect to follow:
```
