### PR TITLE
Disable automatic redirects

### DIFF
--- a/core/src/main/java/com/brandwatch/robots/RobotsFactory.java
+++ b/core/src/main/java/com/brandwatch/robots/RobotsFactory.java
@@ -210,6 +210,7 @@ public class RobotsFactory {
                 .register(new UserAgentBinder(config.getUserAgent()))
                 .register(new LoggingClientFilter(this.getClass(), LogLevel.TRACE));
         client.property(ClientProperties.READ_TIMEOUT, config.getReadTimeoutMillis());
+        client.property(ClientProperties.FOLLOW_REDIRECTS, Boolean.FALSE);
         return client;
     }
 


### PR DESCRIPTION
It turns out that by default the http client is configured to automatically follow redirects that don't respect the ClientRequest and ClientResponse filters, as a result it is possible for requests to be made to excluded domains as long [as they use the same protocol](https://stackoverflow.com/questions/1884230/httpurlconnection-doesnt-follow-redirect-from-http-to-https).

Since the `FollowRedirectsFilter#getRedirectResponse` already manually follows redirects we can disable automatic redirects which insures that all requests use of the request filters.

I tested this locally by setting up a nginx server to simulate some nested redirects.

```
        rewrite /robots.txt /robots2.txt permanent;
        rewrite /robots2.txt http://claudiotorres.com.br/robots.txt permanent;
```

Where `http://claudiotorres.com.br/robots.txt` has a redirect to instagram.

BEFORE ([**DEFAULT**](http://javadox.com/org.glassfish.jersey.core/jersey-client/2.6/org/glassfish/jersey/client/ClientProperties.html#FOLLOW_REDIRECTS))
```
./robots http://localhost:8080/ --agent steve --excludedDomains instagram.com                           
18:20:33.011 [main] DEBUG com.brandwatch.robots.RobotsFactory - Initializing factory with config: RobotsConfig{cacheExpiresHours=24, cacheMaxSizeRecords=10000, maxFileSizeBytes=196608, maxRedirectHops=5, defaultCharset=UTF-8, userAgent=steve, requestTimeoutMillis=10000, readTimeoutMillis=30000, excludedDomains=[instagram.com]}
18:20:33.077 [main] DEBUG com.brandwatch.robots.RobotsFactory - Initializing cache (maxSize: 10000, expires after: 24 hours)
18:20:33.099 [main] DEBUG c.b.robots.RobotsServiceImpl - Resolving robots URL for: http://localhost:8080/
18:20:33.101 [main] DEBUG c.b.robots.RobotsServiceImpl - Resolved robots URI to: http://localhost:8080/robots.txt
18:20:33.189 [main] DEBUG c.brandwatch.robots.RobotsLoaderImpl - Loading: http://localhost:8080/robots.txt
18:20:33.445 [jersey-client-async-executor-0] DEBUG com.brandwatch.robots.RobotsFactory - Request: GET http://localhost:8080/robots.txt {Accept=[text/plain; charset=UTF-8], User-Agent=[steve]}
18:20:33.902 [jersey-client-async-executor-0] DEBUG c.b.robots.net.FollowRedirectsFilter - Redirect location present in domain exclusions: http://localhost:8080/robots.txt -> https://www.instagram.com/claudiotorreseng/
18:20:33.903 [main] DEBUG c.b.robots.RobotsServiceImpl - Disallowing: http://localhost:8080/
http://localhost:8080/: disallowed
```
_see http://localhost:8080/robots.txt redirects directly to https://www.instagram.com/claudiotorreseng/, note only one request is logged_

AFTER
```
./robots http://localhost:8080/ --agent steve --excludedDomains instagram.com                           
18:18:25.827 [main] DEBUG com.brandwatch.robots.RobotsFactory - Initializing factory with config: RobotsConfig{cacheExpiresHours=24, cacheMaxSizeRecords=10000, maxFileSizeBytes=196608, maxRedirectHops=5, defaultCharset=UTF-8, userAgent=steve, requestTimeoutMillis=10000, readTimeoutMillis=30000, excludedDomains=[instagram.com]}
18:18:25.890 [main] DEBUG com.brandwatch.robots.RobotsFactory - Initializing cache (maxSize: 10000, expires after: 24 hours)
18:18:25.911 [main] DEBUG c.b.robots.RobotsServiceImpl - Resolving robots URL for: http://localhost:8080/
18:18:25.912 [main] DEBUG c.b.robots.RobotsServiceImpl - Resolved robots URI to: http://localhost:8080/robots.txt
18:18:25.999 [main] DEBUG c.brandwatch.robots.RobotsLoaderImpl - Loading: http://localhost:8080/robots.txt
18:18:26.266 [jersey-client-async-executor-0] DEBUG com.brandwatch.robots.RobotsFactory - Request: GET http://localhost:8080/robots.txt {Accept=[text/plain; charset=UTF-8], User-Agent=[steve]}
18:18:26.324 [jersey-client-async-executor-0] DEBUG c.b.robots.net.FollowRedirectsFilter - Following redirect: http://localhost:8080/robots.txt => http://localhost:8080/robots2.txt
18:18:26.325 [jersey-client-async-executor-0] DEBUG com.brandwatch.robots.RobotsFactory - Request: GET http://localhost:8080/robots2.txt {Accept=[text/plain; charset=UTF-8], User-Agent=[steve]}
18:18:26.326 [jersey-client-async-executor-0] DEBUG c.b.robots.net.FollowRedirectsFilter - Following redirect: http://localhost:8080/robots2.txt => http://claudiotorres.com.br/robots.txt
18:18:26.327 [jersey-client-async-executor-0] DEBUG com.brandwatch.robots.RobotsFactory - Request: GET http://claudiotorres.com.br/robots.txt {Accept=[text/plain; charset=UTF-8], User-Agent=[steve]}
18:18:27.811 [jersey-client-async-executor-0] DEBUG c.b.robots.net.FollowRedirectsFilter - Redirect location present in domain exclusions: http://claudiotorres.com.br/robots.txt -> https://www.instagram.com/claudiotorreseng/
18:18:27.813 [main] DEBUG c.b.robots.RobotsServiceImpl - Disallowing: http://localhost:8080/
http://localhost:8080/: disallowed
```
_note each redirect was logged individually_